### PR TITLE
Gdm test scenarios

### DIFF
--- a/fedora/profiles/pci-dss.profile
+++ b/fedora/profiles/pci-dss.profile
@@ -98,6 +98,7 @@ selections:
     - account_disable_post_pw_expiration
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -121,6 +121,7 @@ selections:
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
     - account_unique_name
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_enabled

--- a/ol7/profiles/stig.profile
+++ b/ol7/profiles/stig.profile
@@ -109,6 +109,7 @@ selections:
     - audit_rules_usergroup_modification_opasswd
     - audit_rules_usergroup_modification_passwd
     - audit_rules_usergroup_modification_shadow
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_activation_locked
     - dconf_gnome_screensaver_idle_delay

--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -42,6 +42,7 @@ selections:
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_dmesg_restrict
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay

--- a/ol8/profiles/pci-dss.profile
+++ b/ol8/profiles/pci-dss.profile
@@ -126,6 +126,7 @@ selections:
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
     - account_unique_name
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_enabled

--- a/rhel7/profiles/C2S.profile
+++ b/rhel7/profiles/C2S.profile
@@ -70,6 +70,7 @@ selections:
     - selinux_confinement_of_daemons
     - banner_etc_issue
     - login_banner_text=usgcb_default
+    - dconf_db_up_to_date
     - dconf_gnome_login_banner_text
     - dconf_gnome_banner_enabled
     - security_patches_up_to_date

--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -28,6 +28,7 @@ selections:
     - service_debug-shell_disabled
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_burstaction
+    - dconf_db_up_to_date
     - dconf_gnome_remote_access_credential_prompt
     - dconf_gnome_remote_access_encryption
     - sshd_disable_empty_passwords

--- a/rhel7/profiles/ospp42.profile
+++ b/rhel7/profiles/ospp42.profile
@@ -42,6 +42,7 @@ selections:
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_dmesg_restrict
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay

--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -79,6 +79,7 @@ selections:
     - account_disable_post_pw_expiration
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -57,6 +57,7 @@ selections:
     - rpm_verify_permissions
     - rpm_verify_ownership
     - rpm_verify_hashes
+    - dconf_db_up_to_date
     - dconf_gnome_banner_enabled
     - dconf_gnome_login_banner_text
     - banner_etc_issue

--- a/rhel8/profiles/cjis.profile
+++ b/rhel8/profiles/cjis.profile
@@ -86,6 +86,7 @@ selections:
     - var_password_pam_retry=5
     - var_accounts_passwords_pam_faillock_deny=5
     - var_accounts_passwords_pam_faillock_unlock_time=600
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -28,6 +28,7 @@ selections:
     - service_debug-shell_disabled
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_burstaction
+    - dconf_db_up_to_date
     - dconf_gnome_remote_access_credential_prompt
     - dconf_gnome_remote_access_encryption
     - sshd_disable_empty_passwords

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -219,6 +219,7 @@ selections:
     ### FMT_MOF_EXT.1 / AC-11(a)
     ### Enable Screen Lock
     - package_tmux_installed
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -98,6 +98,7 @@ selections:
     - account_disable_post_pw_expiration
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
+    - dconf_db_up_to_date
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/correct_value.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../../../group_software/group_gnome/dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings"
+
+dconf update

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/correct_value.pass.sh
@@ -3,13 +3,7 @@
 
 . ../../../../group_software/group_gnome/dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/wrong_value.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../../../group_software/group_gnome/dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "false" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings"
+
+dconf update

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_banner_enabled/wrong_value.fail.sh
@@ -3,13 +3,7 @@
 
 . ../../../../group_software/group_gnome/dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "false" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/correct_value.pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../../../group_software/group_gnome/dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+login_banner_text="--[\s\n]+WARNING[\s\n]+--[\s\n]*This[\s\n]+system[\s\n]+is[\s\n]+for[\s\n]+the[\s\n]+use[\s\n]+of[\s\n]+authorized[\s\n]+users[\s\n]+only.[\s\n]+Individuals[\s\n]*using[\s\n]+this[\s\n]+computer[\s\n]+system[\s\n]+without[\s\n]+authority[\s\n]+or[\s\n]+in[\s\n]+excess[\s\n]+of[\s\n]+their[\s\n]*authority[\s\n]+are[\s\n]+subject[\s\n]+to[\s\n]+having[\s\n]+all[\s\n]+their[\s\n]+activities[\s\n]+on[\s\n]+this[\s\n]+system[\s\n]*monitored[\s\n]+and[\s\n]+recorded[\s\n]+by[\s\n]+system[\s\n]+personnel.[\s\n]+Anyone[\s\n]+using[\s\n]+this[\s\n]*system[\s\n]+expressly[\s\n]+consents[\s\n]+to[\s\n]+such[\s\n]+monitoring[\s\n]+and[\s\n]+is[\s\n]+advised[\s\n]+that[\s\n]*if[\s\n]+such[\s\n]+monitoring[\s\n]+reveals[\s\n]+possible[\s\n]+evidence[\s\n]+of[\s\n]+criminal[\s\n]+activity[\s\n]*system[\s\n]+personal[\s\n]+may[\s\n]+provide[\s\n]+the[\s\n]+evidence[\s\n]+of[\s\n]+such[\s\n]+monitoring[\s\n]+to[\s\n]+law[\s\n]*enforcement[\s\n]+officials."
+expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}''" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/correct_value.pass.sh
@@ -3,13 +3,7 @@
 
 . ../../../../group_software/group_gnome/dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 login_banner_text="--[\s\n]+WARNING[\s\n]+--[\s\n]*This[\s\n]+system[\s\n]+is[\s\n]+for[\s\n]+the[\s\n]+use[\s\n]+of[\s\n]+authorized[\s\n]+users[\s\n]+only.[\s\n]+Individuals[\s\n]*using[\s\n]+this[\s\n]+computer[\s\n]+system[\s\n]+without[\s\n]+authority[\s\n]+or[\s\n]+in[\s\n]+excess[\s\n]+of[\s\n]+their[\s\n]*authority[\s\n]+are[\s\n]+subject[\s\n]+to[\s\n]+having[\s\n]+all[\s\n]+their[\s\n]+activities[\s\n]+on[\s\n]+this[\s\n]+system[\s\n]*monitored[\s\n]+and[\s\n]+recorded[\s\n]+by[\s\n]+system[\s\n]+personnel.[\s\n]+Anyone[\s\n]+using[\s\n]+this[\s\n]*system[\s\n]+expressly[\s\n]+consents[\s\n]+to[\s\n]+such[\s\n]+monitoring[\s\n]+and[\s\n]+is[\s\n]+advised[\s\n]+that[\s\n]*if[\s\n]+such[\s\n]+monitoring[\s\n]+reveals[\s\n]+possible[\s\n]+evidence[\s\n]+of[\s\n]+criminal[\s\n]+activity[\s\n]*system[\s\n]+personal[\s\n]+may[\s\n]+provide[\s\n]+the[\s\n]+evidence[\s\n]+of[\s\n]+such[\s\n]+monitoring[\s\n]+to[\s\n]+law[\s\n]*enforcement[\s\n]+officials."
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/wrong_value.fail.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../../../group_software/group_gnome/dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+login_banner_text="Wrong Banner Text"
+expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/group_gui_login_banner/rule_dconf_gnome_login_banner_text/wrong_value.fail.sh
@@ -3,13 +3,7 @@
 
 . ../../../../group_software/group_gnome/dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 login_banner_text="Wrong Banner Text"
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')

--- a/tests/data/group_system/group_software/group_gnome/dconf_test_functions.sh
+++ b/tests/data/group_system/group_software/group_gnome/dconf_test_functions.sh
@@ -4,6 +4,11 @@ clean_dconf_settings(){
 	rm -rf /etc/dconf/db/*
 }
 
+# Wipes out dconf db files
+remove_dconf_databases(){
+	rm -f /etc/dconf/db/*
+}
+
 # Adds a new dconf setting
 # $1 _path
 # $2 _setting
@@ -12,7 +17,7 @@ clean_dconf_settings(){
 # $5 _settingFile
 add_dconf_setting() {
 	local _path=$1 _setting=$2 _value=$3 _db=$4 _settingFile=$5
-	mkdir /etc/dconf/db/${_db}
+	mkdir -p /etc/dconf/db/${_db} || true
 	echo "[${_path}]" > /etc/dconf/db/${_db}/${_settingFile}
 	echo "${_setting}=${_value}" >> /etc/dconf/db/${_db}/${_settingFile}
 }

--- a/tests/data/group_system/group_software/group_gnome/dconf_test_functions.sh
+++ b/tests/data/group_system/group_software/group_gnome/dconf_test_functions.sh
@@ -1,4 +1,15 @@
 
+# Check if gdm and dconf are installed, if not then install them
+install_dconf_and_gdm_if_needed(){
+	if ! rpm -q dconf; then
+		yum -y install dconf
+	fi
+
+	if ! rpm -q gdm; then
+		yum -y install gdm
+	fi
+}
+
 # Wipes out dconf db settings directory
 clean_dconf_settings(){
 	rm -rf /etc/dconf/db/*

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/correct_value.pass.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "true" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/correct_value.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "true" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-restart-buttons" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/wrong_value.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "false" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-restart-buttons" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_restart_shutdown/wrong_value.fail.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "false" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/correct_value.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "disable-user-list" "true" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-user-list" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/correct_value.pass.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "disable-user-list" "true" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/wrong_value.fail.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "disable-user-list" "false" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_disable_user_list/wrong_value.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "disable-user-list" "false" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-user-list" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/correct_value.pass.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "true" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/correct_value.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "true" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "enable-smartcard-authentication" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/wrong_value.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "false" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "enable-smartcard-authentication" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_enable_smartcard_auth/wrong_value.fail.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "false" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/correct_value.pass.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "allowed-failures" "3" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/correct_value.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "allowed-failures" "3" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "allowed-failures" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/wrong_value.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "allowed-failures" "99" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "allowed-failures" "gdm.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_dconf_gnome_login_retries/wrong_value.fail.sh
@@ -3,13 +3,7 @@
 
 . ../../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "allowed-failures" "99" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_not_up_to_date.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_not_up_to_date.fail.sh
@@ -3,13 +3,7 @@
 
 . ../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"
@@ -20,7 +14,9 @@ add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "local.d" "00-se
 
 dconf update
 
-sleep 3
+# ensure that the modification happens a reasonable amount of time after running dconf update
+sleep 5
 
-# make static files newer than the database
+# make static keyfiles newer than the database
 add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "local.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_not_up_to_date.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_not_up_to_date.fail.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings-lock"
+
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "local.d" "00-security-settings-lock"
+
+dconf update
+
+sleep 3
+
+# make static files newer than the database
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_up_to_date.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_up_to_date.pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings-lock"
+
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "local.d" "00-security-settings-lock"
+
+dconf update

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_up_to_date.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/db_up_to_date.pass.sh
@@ -3,13 +3,7 @@
 
 . ../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
 add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/no_db_files.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/no_db_files.fail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../dconf_test_functions.sh
+
+if ! rpm -q dconf; then
+    yum -y install dconf
+fi
+
+if ! rpm -q gdm; then
+    yum -y install gdm
+fi
+
+# remove all database files
+remove_dconf_databases
+
+sleep 3
+
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings-lock"
+
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "local.d" "00-security-settings-lock"

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/no_db_files.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_db_up_to_date/no_db_files.fail.sh
@@ -3,18 +3,13 @@
 
 . ../dconf_test_functions.sh
 
-if ! rpm -q dconf; then
-    yum -y install dconf
-fi
-
-if ! rpm -q gdm; then
-    yum -y install gdm
-fi
+install_dconf_and_gdm_if_needed
 
 # remove all database files
 remove_dconf_databases
 
-sleep 3
+# ensure that the modification happens a reasonable amount of time after running dconf update
+sleep 5
 
 add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "gdm.d" "00-security-settings"
 add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings-lock"


### PR DESCRIPTION
Create test scenarios for:

- gdm dconf rules (the ones who uses gdm.d directory)
- dconf_db_up_to_date

Added rule to desired profiles.